### PR TITLE
pkg/broker/mqtt: improve no connection error message

### DIFF
--- a/pkg/broker/mqtt/mqtt.go
+++ b/pkg/broker/mqtt/mqtt.go
@@ -16,7 +16,7 @@ const clientDisconnectWaitTimeout = 250
 
 var _ broker.Broker = (*mqttBroker)(nil)
 
-var ErrNoConnection = errors.New("no connection")
+var ErrNoConnection = errors.New("no connection to broker server")
 
 var tokenWaitTimeout = 3 * time.Second
 


### PR DESCRIPTION
Make it clear to caller that the broker client is not connected to
broker server.