### PR TITLE
pkg/broker/mqtt: set last will testatement

### DIFF
--- a/pkg/broker/mqtt/mqtt.go
+++ b/pkg/broker/mqtt/mqtt.go
@@ -12,7 +12,10 @@ import (
 	"github.com/bizflycloud/bizfly-backup/pkg/broker"
 )
 
-const clientDisconnectWaitTimeout = 250
+const (
+	clientDisconnectWaitTimeout = 250
+	lastWillTestatement         = `{"status": "OFFLINE"}`
+)
 
 var _ broker.Broker = (*mqttBroker)(nil)
 
@@ -55,6 +58,7 @@ func (m *mqttBroker) Connect() error {
 	opts.SetPassword(password)
 	opts.SetClientID(m.clientID)
 	opts.SetCleanSession(false)
+	opts.SetWill("agent/"+m.clientID, lastWillTestatement, 0, false)
 
 	client := mqtt.NewClient(opts)
 	token := client.Connect()


### PR DESCRIPTION
A test is not doable at this time, using Disconnect won't cause the
last will testatement fired.

See https://github.com/eclipse/paho.mqtt.golang/blob/118a68466396fe2c8601804bc9889e73de278f6b/fvt_client_test.go#L196